### PR TITLE
Add Docker setup and updated README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build frontend
+FROM node:20 AS frontend-builder
+WORKDIR /frontend
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend/ ./
+RUN npm run build
+
+# Final image
+FROM python:3.11-slim
+WORKDIR /app
+# install backend dependencies
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN pip install --no-cache-dir -r backend/requirements.txt
+# copy backend code
+COPY backend/ ./backend
+# copy built frontend
+COPY --from=frontend-builder /frontend/build ./frontend/build
+# copy start script
+COPY start.sh ./start.sh
+RUN chmod +x start.sh
+EXPOSE 80 8000
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # lpr
-lpr is huge 
+
+This repository contains a React frontend and a FastAPI backend.
+
+## Build the Frontend
+
+```
+cd frontend
+npm install
+npm run build
+```
+
+The compiled files will be generated in `frontend/build`.
+
+## Start the Backend
+
+After installing the Python dependencies you can run the API with Uvicorn:
+
+```
+uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+```
+
+## Docker
+
+A `Dockerfile` is provided to build an image containing both the backend and the
+pre-built frontend. The container exposes port `8000` for the API and port `80`
+for the static frontend.
+
+Build and run the container:
+
+```
+docker build -t lpr-app .
+docker run -p 8000:8000 -p 80:80 lpr-app
+```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+python-dotenv
+azure-cosmos
+stripe
+passlib[bcrypt]
+python-jose[cryptography]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+python -m http.server 80 --directory /app/frontend/build &
+exec uvicorn backend.app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add Dockerfile to build frontend and serve backend
- include backend requirements
- create start script running frontend and backend
- document build/run steps in README

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854645f42348323bf4b23009d386034