### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Compile backend Python files
+        run: python -m py_compile backend/app/*.py
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies and build both parts of the app

## Testing
- `python -m py_compile app/*.py`
- `npm run build` *(fails: react-scripts not found)*
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68546a7f72c08323977ee485285c9c95